### PR TITLE
feat: Add About Me and CTA sections to homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -125,6 +125,47 @@ export default function Home() {
           </div>
         </div>
       </section>
+
+      {/* About Me Section */}
+      <section className="bg-[#F4F6F8] py-24">
+        <div className="container mx-auto px-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
+            {/* Left Column: Image Placeholder */}
+            <div className="bg-gray-300 aspect-[3/4] rounded-lg w-full max-w-sm mx-auto"></div>
+
+            {/* Right Column: Text Content */}
+            <div className="text-left">
+              <h2 className="text-4xl font-bold font-poppins text-[#1F2937]">
+                O Engenheiro, Gestor e Inovador por Trás dos Resultados
+              </h2>
+              <p className="font-inter text-gray-600 mt-6 text-lg">
+                Com mais de 15 anos de experiência, uno a precisão da engenharia de campo, a visão estratégica de negócios de MBAs pela FGV e USP, e a paixão por tecnologia para criar soluções que geram valor real. Meu objetivo é transformar seus desafios mais complexos em ativos de performance.
+              </p>
+              <p className="font-inter text-gray-600 mt-4 text-lg">
+                Atuo como Perito Judicial no TJPR, aplicando o mais alto padrão de rigor técnico e ético em todos os projetos.
+              </p>
+              <a href="#" className="bg-navy-blue hover:opacity-90 text-white font-bold py-3 px-6 rounded-lg mt-8 inline-block transition-opacity">
+                Conheça minha trajetória
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA Section */}
+      <section className="bg-navy-blue text-white py-20">
+        <div className="container mx-auto px-4 text-center">
+          <h2 className="text-4xl font-bold font-poppins">
+            Pronto para Transformar Sua Operação?
+          </h2>
+          <p className="text-lg font-inter mt-4 max-w-3xl mx-auto">
+            Vamos conversar sobre como a engenharia estratégica e as soluções de IA personalizadas podem reduzir seus custos e aumentar a eficiência dos seus ativos.
+          </p>
+          <a href="#" className="bg-burnt-orange hover:bg-orange-700 text-white font-bold py-4 px-8 rounded-lg mt-8 inline-block text-lg transition-colors">
+            Entre em Contato
+          </a>
+        </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
This commit adds two new content sections to the homepage (`app/page.tsx`) as per your requirements.

1.  **About Me Section**:
    *   A responsive 2-column grid with a placeholder for a photo on the left and descriptive text on the right.
    *   Styled with a light gray background (`#F4F6F8`).
    *   Includes a button-styled link to the "About" page.

2.  **Call to Action (CTA) Section**:
    *   A full-width section with a navy blue background (`#0D2C4D`) and white text.
    *   Features a prominent headline, a paragraph, and a large call-to-action button.
    *   All content is centered with significant vertical padding.

The new sections use the existing color palette and font styles defined in the Tailwind CSS configuration to ensure visual consistency with the rest of the page.